### PR TITLE
Add mobile menu and admin editing

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,7 +35,12 @@
         <img src="assets/logo.png" alt="Logo" class="w-8" />
         <span class="font-semibold">Caja de Ahorro Estadística</span>
       </div>
-      <div class="space-x-4">
+      <button id="menu-toggle" class="md:hidden">
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+        </svg>
+      </button>
+      <div id="desktop-menu" class="space-x-4 hidden md:flex">
         <a href="#/dashboard" class="hover:underline">Dashboard</a>
         <a href="#/usuarios" class="hover:underline">Usuarios</a>
         <a href="#/pagos" class="hover:underline">Pagos</a>
@@ -44,6 +49,26 @@
         <button id="logout" class="ml-4 bg-red-500 text-white px-3 py-1 rounded">Salir</button>
       </div>
     </nav>
+    <div id="mobile-menu" class="fixed inset-0 bg-black bg-opacity-50 hidden z-50">
+      <div class="bg-white w-64 h-full p-4">
+        <div class="flex justify-between items-center mb-4">
+          <span class="font-semibold">Menú</span>
+          <button id="menu-close">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+        <nav class="flex flex-col space-y-2">
+          <a href="#/dashboard" class="hover:underline">Dashboard</a>
+          <a href="#/usuarios" class="hover:underline">Usuarios</a>
+          <a href="#/pagos" class="hover:underline">Pagos</a>
+          <a href="#/egresos" class="hover:underline">Egresos</a>
+          <a href="#/estado" class="hover:underline">Estado de cuenta</a>
+          <button id="logout-mobile" class="mt-4 bg-red-500 text-white px-3 py-1 rounded">Salir</button>
+        </nav>
+      </div>
+    </div>
 
     <main class="p-4">
       <!-- Dashboard -->
@@ -83,6 +108,7 @@
               <th class="py-2">Correo</th>
               <th class="py-2">Rol</th>
               <th class="py-2">Activo</th>
+              <th id="usuarios-acciones" class="py-2 hidden">Acciones</th>
             </tr>
           </thead>
           <tbody id="tabla-usuarios"></tbody>
@@ -106,6 +132,7 @@
               <th class="py-2">Quincena</th>
               <th class="py-2">Fecha</th>
               <th class="py-2">Monto</th>
+              <th id="pagos-acciones" class="py-2 hidden">Acciones</th>
             </tr>
           </thead>
           <tbody id="tabla-pagos"></tbody>
@@ -129,6 +156,7 @@
               <th class="py-2">Concepto</th>
               <th class="py-2">Monto</th>
               <th class="py-2">Detalle</th>
+              <th id="egresos-acciones" class="py-2 hidden">Acciones</th>
             </tr>
           </thead>
           <tbody id="tabla-egresos"></tbody>


### PR DESCRIPTION
## Summary
- Switch mobile navigation to a hamburger menu with overlay and dismiss options
- Allow administrators to edit users, payments and expenses from tables

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689120dbb44883259d62f29a8e6c0e63