### PR TITLE
feat: manage fixed biweekly payments

### DIFF
--- a/index.html
+++ b/index.html
@@ -142,6 +142,7 @@
               <option value="false">No</option>
             </select>
             <input id="usuario-cumple" type="date" class="w-full border p-2 rounded" required />
+            <input id="usuario-ingreso" type="date" class="w-full border p-2 rounded" required />
             <button type="submit" class="w-full bg-green-600 text-white py-2 rounded">Guardar</button>
           </form>
         </div>
@@ -152,7 +153,6 @@
         <h2 class="text-2xl font-bold mb-4">Pagos</h2>
         <div id="form-pago" class="mb-4 hidden">
           <select id="pago-integrante" class="border p-2 mr-2"></select>
-          <input id="pago-quincena" type="text" placeholder="YYYY-Q##" class="border p-2 mr-2" />
           <input id="pago-fecha" type="date" class="border p-2 mr-2" />
           <input id="pago-monto" type="number" class="border p-2 mr-2 w-24" />
           <button id="guardar-pago" class="bg-green-600 text-white px-3 py-1 rounded">Guardar</button>
@@ -162,8 +162,9 @@
             <tr>
               <th class="py-2">Integrante</th>
               <th class="py-2">Quincena</th>
-              <th class="py-2">Fecha</th>
-              <th class="py-2">Monto</th>
+              <th class="py-2">Fecha límite</th>
+              <th class="py-2">Abonado</th>
+              <th class="py-2">Estatus</th>
               <th id="pagos-acciones" class="py-2 hidden">Acciones</th>
             </tr>
           </thead>


### PR DESCRIPTION
## Summary
- generate and maintain biweekly payment schedule per member
- apply deposits chronologically and update payment status
- show account statements with payment status summary

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6891506e3b788325ad6091921a24a6ff