### PR TITLE
feat: add quincena payment tracking

### DIFF
--- a/index.html
+++ b/index.html
@@ -200,15 +200,23 @@
       <div id="modal-detalle" class="fixed inset-0 bg-black/40 hidden items-center justify-center">
         <div class="bg-white rounded-lg p-6 w-full max-w-md">
           <h3 class="text-xl font-bold mb-4">Historial de abonos</h3>
-          <ul id="lista-historial" class="space-y-2"></ul>
-          <button id="cerrar-detalle" class="mt-4 bg-blue-600 text-white px-4 py-2 rounded">Cerrar</button>
+          <ul id="lista-historial" class="space-y-2 mb-4"></ul>
+          <div class="flex justify-end space-x-2">
+            <button id="exportar-detalle" class="bg-green-600 text-white px-4 py-2 rounded">Exportar</button>
+            <button id="cerrar-detalle" class="bg-blue-600 text-white px-4 py-2 rounded">Cerrar</button>
+          </div>
         </div>
       </div>
 
       <div id="modal-abono" class="fixed inset-0 bg-black/40 hidden items-center justify-center">
         <div class="bg-white rounded-lg p-6 w-full max-w-md">
           <h3 class="text-xl font-bold mb-4">Registrar abono</h3>
+          <select id="abono-usuario" class="border p-2 w-full mb-4"></select>
           <input id="input-abono" type="number" class="border p-2 w-full mb-4" placeholder="Monto" />
+          <select id="abono-tipo" class="border p-2 w-full mb-4">
+            <option value="quincenal">quincenal</option>
+            <option value="anticipado">anticipado</option>
+          </select>
           <div class="flex justify-end space-x-2">
             <button id="abono-cancelar" class="px-4 py-2 border rounded">Cancelar</button>
             <button id="abono-guardar" class="px-4 py-2 bg-green-600 text-white rounded">Guardar</button>


### PR DESCRIPTION
## Summary
- generate 24 annual quincenas using active users to set expected amount
- track user abonos in subcollections and update quincena status
- add mobile UI with user/type selection, progress bar and PDF export

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68915f19c4648325b30a422d9485b9e4