### PR TITLE
feat: add quincena payment accordion

### DIFF
--- a/index.html
+++ b/index.html
@@ -151,7 +151,8 @@
       <!-- Pagos -->
       <section id="view-pagos" class="view hidden pb-24">
         <h2 class="text-2xl font-bold mb-4">Pagos</h2>
-        <div id="cards-pagos" class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3"></div>
+        <button id="exportar-pagos" class="mb-4 bg-blue-600 text-white px-3 py-1 rounded">Exportar PDF</button>
+        <div id="cards-pagos" class="space-y-4"></div>
         <button id="ver-mas" class="mt-4 w-full bg-blue-600 text-white py-2 rounded hidden">Ver más</button>
         <div id="barra-abono-global" class="hidden fixed bottom-0 left-0 right-0 bg-white border-t p-4">
           <div class="flex justify-center">


### PR DESCRIPTION
## Summary
- add collapsible quincena cards with per-user payment checklists
- write/remove abonos documents on checkbox toggle and update status
- allow exporting payment status to PDF

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689163e65bfc8325a388b461f7b58635