### PR TITLE
Remove obsolete ingreso field and fix payment expectation

### DIFF
--- a/index.html
+++ b/index.html
@@ -142,7 +142,6 @@
               <option value="false">No</option>
             </select>
             <input id="usuario-cumple" type="date" class="w-full border p-2 rounded" required />
-            <input id="usuario-ingreso" type="date" class="w-full border p-2 rounded" required />
             <button type="submit" class="w-full bg-green-600 text-white py-2 rounded">Guardar</button>
           </form>
         </div>


### PR DESCRIPTION
## Summary
- remove "fecha de ingreso" field from user modal and logic
- use integrantes collection to compute expected amounts
- recalc expected payment based on active users when loading pagos

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68916b86d3508325b86093e3d2cd7c9a