### PR TITLE
Rediseño responsivo de integrantes

### DIFF
--- a/index.html
+++ b/index.html
@@ -99,28 +99,14 @@
       <section id="view-usuarios" class="view hidden">
         <div class="max-w-4xl mx-auto">
           <div class="bg-white shadow rounded-lg p-4">
-            <div class="flex justify-between items-center mb-4">
-              <h2 class="text-2xl font-bold">Integrantes</h2>
-            </div>
-            <div class="overflow-x-auto">
-              <table class="min-w-full">
-                <thead class="bg-gray-100">
-                  <tr>
-                    <th class="px-4 py-2 text-left">Nombre</th>
-                    <th class="px-4 py-2 text-left">Correo</th>
-                    <th class="px-4 py-2 text-left">Rol</th>
-                    <th class="px-4 py-2 text-left">Activo</th>
-                    <th class="px-4 py-2 text-left">Cumpleaños</th>
-                    <th id="usuarios-acciones" class="px-4 py-2 text-left hidden">Acciones</th>
-                  </tr>
-                </thead>
-                <tbody id="tabla-usuarios"></tbody>
-              </table>
-            </div>
+          <div class="flex justify-between items-center mb-4">
+            <h2 class="text-2xl font-bold">Integrantes</h2>
           </div>
+          <div id="lista-usuarios" class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4 max-h-[70vh] overflow-y-auto"></div>
         </div>
-        <button id="btn-add-usuario" class="hidden fixed bottom-6 right-6 bg-blue-600 text-white rounded-full w-12 h-12 flex items-center justify-center text-3xl shadow-lg">+</button>
-      </section>
+      </div>
+      <button id="btn-add-usuario" class="hidden fixed bottom-6 right-6 bg-blue-600 text-white rounded-full w-12 h-12 flex items-center justify-center text-3xl shadow-lg">+</button>
+    </section>
 
       <div id="modal-usuario" class="hidden fixed inset-0 flex items-center justify-center bg-black/40">
         <div class="bg-white rounded-lg shadow p-6 w-full max-w-md">

--- a/js/app.js
+++ b/js/app.js
@@ -210,7 +210,6 @@ function setupForms() {
   if (currentRole === 'admin') {
     document.getElementById('form-egreso').classList.remove('hidden');
     document.getElementById('btn-add-usuario').classList.remove('hidden');
-    document.getElementById('usuarios-acciones').classList.remove('hidden');
     document.getElementById('egresos-acciones').classList.remove('hidden');
     btnAddPago?.classList.remove('hidden');
   }
@@ -272,32 +271,30 @@ formUsuario?.addEventListener('submit', async e => {
 // Usuarios
 async function loadUsuarios() {
   try {
-    const tbody = document.getElementById('tabla-usuarios');
-    tbody.innerHTML = '';
+    const cont = document.getElementById('lista-usuarios');
+    cont.innerHTML = '';
     const snap = await getDocs(collection(db, 'integrantes'));
-    snap.forEach(docu => {
-      const d = docu.data();
-      const tr = document.createElement('tr');
-      tr.className = 'border-b odd:bg-white even:bg-gray-50';
-      tr.innerHTML = `
-        <td class="px-4 py-2">${d.nombre}</td>
-        <td class="px-4 py-2">${d.email}</td>
-        <td class="px-4 py-2">${d.rol}</td>
-        <td class="px-4 py-2">${d.activo ? 'Sí' : 'No'}</td>
-        <td class="px-4 py-2">${formatDate(d.cumple)}</td>
-        ${currentRole === 'admin' ? `<td class="px-4 py-2 space-x-2">
-            <button class="edit-usuario" data-id="${docu.id}" data-nombre="${d.nombre}" data-email="${d.email}" data-rol="${d.rol}" data-activo="${d.activo}" data-cumple="${d.cumple}">✏️</button>
-            <button class="delete-usuario" data-id="${docu.id}">🗑️</button>
-          </td>` : ''}
-      `;
-      tbody.appendChild(tr);
-    });
     const selPago = document.getElementById('pago-integrante');
     const selEstado = document.getElementById('estado-integrante');
     if (selPago) selPago.innerHTML = '<option value="">Integrante</option>';
     if (selEstado) selEstado.innerHTML = '';
     snap.forEach(docu => {
       const d = docu.data();
+      const card = document.createElement('div');
+      card.className = 'bg-white rounded-xl shadow-md p-4 mb-3 w-full max-w-md mx-auto';
+      card.innerHTML = `
+        <p class="font-bold">${d.nombre}</p>
+        <p class="text-sm"><span class="mr-1">🛡️</span>${d.rol}</p>
+        <p class="text-sm"><span class="mr-1">${d.activo ? '✅' : '❌'}</span>Activo: ${d.activo ? 'Sí' : 'No'}</p>
+        <p class="text-sm"><span class="mr-1">🎂</span>${formatDate(d.cumple)}</p>
+        ${currentRole === 'admin' ? `
+          <div class="mt-4 flex space-x-2">
+            <button class="edit-usuario flex-1 bg-blue-600 text-white py-2 rounded" data-id="${docu.id}" data-nombre="${d.nombre}" data-email="${d.email}" data-rol="${d.rol}" data-activo="${d.activo}" data-cumple="${d.cumple}">✏️ Editar</button>
+            <button class="delete-usuario flex-1 bg-red-600 text-white py-2 rounded" data-id="${docu.id}">🗑 Eliminar</button>
+          </div>
+        ` : ''}
+      `;
+      cont.appendChild(card);
       if (selPago) selPago.innerHTML += `<option value="${docu.id}">${d.nombre}</option>`;
       if (selEstado) selEstado.innerHTML += `<option value="${docu.id}">${d.nombre}</option>`;
     });
@@ -306,7 +303,7 @@ async function loadUsuarios() {
   }
 }
 
-document.getElementById('tabla-usuarios')?.addEventListener('click', async e => {
+document.getElementById('lista-usuarios')?.addEventListener('click', async e => {
   const target = e.target;
   if (target.classList.contains('edit-usuario')) {
     openUsuarioModal({


### PR DESCRIPTION
## Summary
- Replace integrantes table with responsive grid of cards
- Render user info with role, status, birthday, and action buttons
- Add scrollable container and update event handlers

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6891727e72a48325986c1f0941b1a742