### PR TITLE
Close mobile menu on item click and add hover styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,12 +39,12 @@
         </svg>
       </button>
       <div id="desktop-menu" class="space-x-4 hidden md:flex">
-        <a href="#/dashboard" class="hover:underline">Dashboard</a>
-        <a href="#/usuarios" class="hover:underline">Usuarios</a>
-        <a href="#/pagos" class="hover:underline">Pagos</a>
-        <a href="#/egresos" class="hover:underline">Egresos</a>
-        <a href="#/estado" class="hover:underline">Estado de cuenta</a>
-        <button id="logout" class="ml-4 bg-red-500 text-white px-3 py-1 rounded">Salir</button>
+        <a href="#/dashboard" class="px-2 py-1 rounded hover:bg-gray-200 hover:underline">Dashboard</a>
+        <a href="#/usuarios" class="px-2 py-1 rounded hover:bg-gray-200 hover:underline">Usuarios</a>
+        <a href="#/pagos" class="px-2 py-1 rounded hover:bg-gray-200 hover:underline">Pagos</a>
+        <a href="#/egresos" class="px-2 py-1 rounded hover:bg-gray-200 hover:underline">Egresos</a>
+        <a href="#/estado" class="px-2 py-1 rounded hover:bg-gray-200 hover:underline">Estado de cuenta</a>
+        <button id="logout" class="ml-4 bg-red-500 text-white px-3 py-1 rounded hover:bg-red-600">Salir</button>
       </div>
     </nav>
     <div id="mobile-menu" class="fixed inset-0 bg-black bg-opacity-50 hidden z-50">
@@ -58,12 +58,12 @@
           </button>
         </div>
         <nav class="flex flex-col space-y-2">
-          <a href="#/dashboard" class="hover:underline">Dashboard</a>
-          <a href="#/usuarios" class="hover:underline">Usuarios</a>
-          <a href="#/pagos" class="hover:underline">Pagos</a>
-          <a href="#/egresos" class="hover:underline">Egresos</a>
-          <a href="#/estado" class="hover:underline">Estado de cuenta</a>
-          <button id="logout-mobile" class="mt-4 bg-red-500 text-white px-3 py-1 rounded">Salir</button>
+          <a href="#/dashboard" class="block px-2 py-1 rounded hover:bg-gray-200 hover:underline">Dashboard</a>
+          <a href="#/usuarios" class="block px-2 py-1 rounded hover:bg-gray-200 hover:underline">Usuarios</a>
+          <a href="#/pagos" class="block px-2 py-1 rounded hover:bg-gray-200 hover:underline">Pagos</a>
+          <a href="#/egresos" class="block px-2 py-1 rounded hover:bg-gray-200 hover:underline">Egresos</a>
+          <a href="#/estado" class="block px-2 py-1 rounded hover:bg-gray-200 hover:underline">Estado de cuenta</a>
+          <button id="logout-mobile" class="mt-4 bg-red-500 text-white px-3 py-1 rounded hover:bg-red-600">Salir</button>
         </nav>
       </div>
     </div>

--- a/js/app.js
+++ b/js/app.js
@@ -189,6 +189,9 @@ menuClose?.addEventListener('click', () => mobileMenu.classList.add('hidden'));
 mobileMenu?.addEventListener('click', e => {
   if (e.target === mobileMenu) mobileMenu.classList.add('hidden');
 });
+mobileMenu?.querySelectorAll('a, button').forEach(el => {
+  el.addEventListener('click', () => mobileMenu.classList.add('hidden'));
+});
 
 onAuthStateChanged(auth, async user => {
   if (user) {


### PR DESCRIPTION
## Summary
- Close hamburger menu when clicking any navigation item.
- Add hover background and button hover styles for desktop and mobile menus.

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6892552fb37c832596aff12e6fc1b14f