### PR TITLE
Remove Incompleto status and refine account statement PDF

### DIFF
--- a/index.html
+++ b/index.html
@@ -153,7 +153,6 @@
         <h2 class="text-2xl font-bold mb-4">Pagos</h2>
         <div class="mb-4 flex space-x-2">
           <button id="btn-add-pago" class="bg-green-600 text-white px-3 py-1 rounded hidden">➕ Nueva fecha de pago</button>
-          <button id="exportar-pagos" class="bg-blue-600 text-white px-3 py-1 rounded">Exportar PDF</button>
         </div>
         <div id="cards-pagos" class="space-y-4"></div>
         <button id="ver-mas" class="mt-4 w-full bg-blue-600 text-white py-2 rounded hidden">Ver más</button>


### PR DESCRIPTION
## Summary
- remove Exportar PDF button from payments view
- drop `Incompleto` status from payments and summaries
- add header with member name and print date when exporting account statements to PDF

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689258df66dc8325a7387a3fcbc12e4b