### PR TITLE
Fix PDF export source and Toastify styling

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -20,7 +20,13 @@ import {
 
 // Helpers
 const toast = msg => {
-  Toastify({ text: msg, duration: 3000, gravity: 'top', position: 'right', backgroundColor: '#2563eb' }).showToast();
+  Toastify({
+    text: msg,
+    duration: 3000,
+    gravity: 'top',
+    position: 'right',
+    style: { background: '#2563eb' }
+  }).showToast();
 };
 
 // Generic error handler
@@ -739,7 +745,7 @@ btnExportar?.addEventListener('click', async () => {
   wrapper.appendChild(tabla);
   document.body.appendChild(wrapper);
   try {
-    await html2pdf({ margin: 10 }).from(wrapper).save();
+    await html2pdf().set({ margin: 10 }).from(wrapper).save();
   } catch (err) {
     handleError(err, 'No se pudo exportar el PDF');
   } finally {


### PR DESCRIPTION
## Summary
- adapt Toastify to use `style.background` instead of deprecated `backgroundColor`
- ensure html2pdf receives options via `.set({margin: 10})` to avoid `Unknown source type`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68925d9169d0832585d7cf4cc7576722