### PR TITLE
feat: add default empty option in estado selector

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -306,7 +306,7 @@ async function loadUsuarios() {
     const selPago = document.getElementById('pago-integrante');
     const selEstado = document.getElementById('estado-integrante');
     if (selPago) selPago.innerHTML = '<option value="">Integrante</option>';
-    if (selEstado) selEstado.innerHTML = '';
+    if (selEstado) selEstado.innerHTML = '<option value=""></option>';
     snap.forEach(docu => {
       const d = docu.data();
       const card = document.createElement('div');


### PR DESCRIPTION
## Summary
- ensure account statement user dropdown starts with a blank option

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68925f651110832598363e7ef4bf123f