### PR TITLE
Ordena egresos y ajusta interfaz

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,11 +39,11 @@
         </svg>
       </button>
       <div id="desktop-menu" class="space-x-4 hidden md:flex">
-        <a href="#/dashboard" class="px-2 py-1 rounded hover:bg-gray-200 hover:underline">Dashboard</a>
-        <a href="#/usuarios" class="px-2 py-1 rounded hover:bg-gray-200 hover:underline">Usuarios</a>
-        <a href="#/pagos" class="px-2 py-1 rounded hover:bg-gray-200 hover:underline">Pagos</a>
-        <a href="#/egresos" class="px-2 py-1 rounded hover:bg-gray-200 hover:underline">Egresos</a>
-        <a href="#/estado" class="px-2 py-1 rounded hover:bg-gray-200 hover:underline">Estado de cuenta</a>
+        <a href="#/dashboard" class="px-2 py-1 rounded hover:bg-gray-200 no-underline">Dashboard</a>
+        <a href="#/usuarios" class="px-2 py-1 rounded hover:bg-gray-200 no-underline">Usuarios</a>
+        <a href="#/pagos" class="px-2 py-1 rounded hover:bg-gray-200 no-underline">Pagos</a>
+        <a href="#/egresos" class="px-2 py-1 rounded hover:bg-gray-200 no-underline">Egresos</a>
+        <a href="#/estado" class="px-2 py-1 rounded hover:bg-gray-200 no-underline">Estado de cuenta</a>
         <button id="logout" class="ml-4 bg-red-500 text-white px-3 py-1 rounded hover:bg-red-600">Salir</button>
       </div>
     </nav>
@@ -58,11 +58,11 @@
           </button>
         </div>
         <nav class="flex flex-col space-y-2">
-          <a href="#/dashboard" class="block px-2 py-1 rounded hover:bg-gray-200 hover:underline">Dashboard</a>
-          <a href="#/usuarios" class="block px-2 py-1 rounded hover:bg-gray-200 hover:underline">Usuarios</a>
-          <a href="#/pagos" class="block px-2 py-1 rounded hover:bg-gray-200 hover:underline">Pagos</a>
-          <a href="#/egresos" class="block px-2 py-1 rounded hover:bg-gray-200 hover:underline">Egresos</a>
-          <a href="#/estado" class="block px-2 py-1 rounded hover:bg-gray-200 hover:underline">Estado de cuenta</a>
+          <a href="#/dashboard" class="block px-2 py-1 rounded hover:bg-gray-200 no-underline">Dashboard</a>
+          <a href="#/usuarios" class="block px-2 py-1 rounded hover:bg-gray-200 no-underline">Usuarios</a>
+          <a href="#/pagos" class="block px-2 py-1 rounded hover:bg-gray-200 no-underline">Pagos</a>
+          <a href="#/egresos" class="block px-2 py-1 rounded hover:bg-gray-200 no-underline">Egresos</a>
+          <a href="#/estado" class="block px-2 py-1 rounded hover:bg-gray-200 no-underline">Estado de cuenta</a>
           <button id="logout-mobile" class="mt-4 bg-red-500 text-white px-3 py-1 rounded hover:bg-red-600">Salir</button>
         </nav>
       </div>
@@ -105,7 +105,7 @@
           </div>
         </div>
         <div class="mt-8">
-          <h3 class="font-semibold mb-2">Próximos cumpleaños</h3>
+          <h3 class="font-semibold mb-2 text-center">Próximos Cumpleaños</h3>
           <div id="cumples" class="space-y-3"></div>
         </div>
       </section>

--- a/js/app.js
+++ b/js/app.js
@@ -507,7 +507,7 @@ async function loadEgresos() {
   try {
     const tbody = document.getElementById('tabla-egresos');
     tbody.innerHTML = '';
-    const snap = await getDocs(collection(db, 'egresos'));
+    const snap = await getDocs(query(collection(db, 'egresos'), orderBy('fecha', 'desc')));
     let total = 0;
     snap.forEach(doc => {
       const e = doc.data();


### PR DESCRIPTION
## Resumen
- Ordena la tabla de egresos del más reciente al más antiguo.
- Centra el título de la sección de próximos cumpleaños.
- Elimina subrayados de los enlaces del menú, manteniendo solo el efecto hover.

## Pruebas
- `npm test` *(falla: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689380b947348325a082f1e0c363aa3d